### PR TITLE
fix: reduce example-vm storage size

### DIFF
--- a/examples/example-vm.yaml
+++ b/examples/example-vm.yaml
@@ -21,7 +21,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 5Gi
       source:
         registry:
           url: docker://quay.io/containerdisks/fedora:38


### PR DESCRIPTION
Reduce requested storage size from 10gb
to 5gb, because exported VM disk will be
the same size as requested.

Jira-Url: https://issues.redhat.com/browse/CNV-36303