### PR TITLE
fix: add -e flag to exit on error

### DIFF
--- a/run-uploader.sh
+++ b/run-uploader.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Arguments
 VM_NAME=$1


### PR DESCRIPTION
Add -e flag in shell script to exit when
an error is occurred in one of the executed
commands.