### PR TITLE
fix: set arguments to empty values

### DIFF
--- a/examples/kubevirt-disk-uploader-tekton.yaml
+++ b/examples/kubevirt-disk-uploader-tekton.yaml
@@ -144,9 +144,9 @@ metadata:
   name: kubevirt-disk-uploader-credentials-tekton
 type: Opaque
 data:
-  registryUsername: ""
-  registryPassword: ""
-  registryHostname: ""
+  registryUsername: "<REGISTRY_USERNAME>"
+  registryPassword: "<REGISTRY_PASSWORD>"
+  registryHostname: "<REGISTRY_HOSTNAME>"
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task

--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -55,7 +55,7 @@ spec:
               name: kubevirt-disk-uploader-credentials
               key: registryHostname
       command: ["/usr/local/bin/run-uploader.sh"]
-      args: ["example-vm", "example-vm-exported:latest", "disk.img.gz"]
+      # args: ["<VM_NAME>", "<CONTAINER_DISK_NAME>", "<DISK_FILE>"]
       resources:
         requests:
           memory: 3Gi
@@ -69,6 +69,6 @@ metadata:
   name: kubevirt-disk-uploader-credentials
 type: Opaque
 data:
-  registryUsername: ""
-  registryPassword: ""
-  registryHostname: ""
+  registryUsername: "<REGISTRY_USERNAME>"
+  registryPassword: "<REGISTRY_PASSWORD>"
+  registryHostname: "<REGISTRY_HOSTNAME>"


### PR DESCRIPTION
User will need to change empty values in order to be able to deploy disk uploader.