### PR TITLE
fix: disable virt-sysprep by default

### DIFF
--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -55,7 +55,7 @@ spec:
               name: kubevirt-disk-uploader-credentials
               key: registryHostname
       command: ["/usr/local/bin/kubevirt-disk-uploader"]
-      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--containerdiskname", "example-vm-exported:latest", "--enablevirtsysprep"]
+      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--containerdiskname", "example-vm-exported:latest", "--enablevirtsysprep", "false"]
       resources:
         requests:
           memory: 3Gi


### PR DESCRIPTION
The new virt-sysprep step was not disabled
by default properly in Tekton parameters.

Jira-Url: https://issues.redhat.com/browse/CNV-34270