### PR TITLE
feat: set containerdisk push timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ KubeVirt Disk Uploader -> Download VM Disk -> Build New Container Disk -> Push T
 **Prerequisites**
 
 1. Ensure Virtual Machine (VM) is powered off. Data from VM can be exported only when it is not used.
-2. Modify [kubevirt-disk-uploader](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L58) arguments (VM Name, Volume Name, New Container Disk Name, and Enable or Disable System Preparation).
+2. Modify [kubevirt-disk-uploader](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L58) arguments (VM Name, Volume Name, New Container Disk Name, Enable or Disable System Preparation and Push Timeout).
 3. Modify [kubevirt-disk-uploader-credentials](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L65-L74) of the external container registry (Username, Password and Hostname).
 
 Deploy `kubevirt-disk-uploader` within the same namespace as the Virtual Machine (VM):

--- a/examples/kubevirt-disk-uploader-tekton.yaml
+++ b/examples/kubevirt-disk-uploader-tekton.yaml
@@ -166,6 +166,9 @@ spec:
   - name: ENABLE_VIRT_SYSPREP
     description: Enable or disable preparation of disk image
     type: string
+  - name: PUSH_TIMEOUT
+    description: ContainerDisk push timeout in minutes
+    type: string
   steps:
   - name: kubevirt-disk-uploader-step
     image: quay.io/boukhano/kubevirt-disk-uploader:latest
@@ -195,6 +198,8 @@ spec:
     - $(params.CONTAINER_DISK_NAME)
     - "--enablevirtsysprep"
     - $(params.ENABLE_VIRT_SYSPREP)
+    - "--pushtimeout"
+    - $(params.PUSH_TIMEOUT)
     computeResources:
       requests:
         memory: "3Gi"
@@ -219,6 +224,9 @@ spec:
   - name: ENABLE_VIRT_SYSPREP
     description: "Enable or disable preparation of disk image"
     type: string
+  - name: PUSH_TIMEOUT
+    description: "ContainerDisk push timeout in minutes"
+    type: string
   tasks:
   - name: deploy-example-vm
     taskRef:
@@ -237,6 +245,8 @@ spec:
       value: "$(params.CONTAINER_DISK_NAME)"
     - name: ENABLE_VIRT_SYSPREP
       value: "$(params.ENABLE_VIRT_SYSPREP)"
+    - name: PUSH_TIMEOUT
+      value: "$(params.PUSH_TIMEOUT)"
   - name: deploy-example-vm-exported
     taskRef:
       name: example-vm-exported-task
@@ -259,5 +269,7 @@ spec:
     value: example-vm-tekton-exported:latest
   - name: ENABLE_VIRT_SYSPREP
     value: true
+  - name: PUSH_TIMEOUT
+    value: 120
   taskRunTemplate:
     serviceAccountName: kubevirt-disk-uploader-tekton

--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -55,7 +55,7 @@ spec:
               name: kubevirt-disk-uploader-credentials
               key: registryHostname
       command: ["/usr/local/bin/kubevirt-disk-uploader"]
-      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--containerdiskname", "example-vm-exported:latest", "--enablevirtsysprep", "false"]
+      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--containerdiskname", "example-vm-exported:latest", "--enablevirtsysprep", "false", "--pushtimeout", "120"]
       resources:
         requests:
           memory: 3Gi

--- a/task/README.md
+++ b/task/README.md
@@ -14,10 +14,11 @@ kubectl apply -f https://raw.githubusercontent.com/codingben/kubevirt-disk-uploa
 
 # Parameters
 
-- VM_NAME: The name of the virtual machine
-- VOLUME_NAME: The volume name of the virtual machine
-- CONTAINER_DISK_NAME: The name of the new image
-- ENABLE_VIRT_SYSPREP: Enable or disable preparation of disk image
+- **VM_NAME**: The name of the virtual machine
+- **VOLUME_NAME**: The volume name of the virtual machine
+- **CONTAINER_DISK_NAME**: The name of the new image
+- **ENABLE_VIRT_SYSPREP**: Enable or disable preparation of disk image
+- **PUSH_TIMEOUT**: ContainerDisk push timeout in minutes
 
 # Usage
 

--- a/task/kubevirt-disk-uploader-task.yaml
+++ b/task/kubevirt-disk-uploader-task.yaml
@@ -25,6 +25,9 @@ spec:
   - name: ENABLE_VIRT_SYSPREP
     description: Enable or disable preparation of disk image
     type: string
+  - name: PUSH_TIMEOUT
+    description: ContainerDisk push timeout in minutes
+    type: string
   steps:
   - name: kubevirt-disk-uploader-step
     image: quay.io/boukhano/kubevirt-disk-uploader:latest
@@ -54,6 +57,8 @@ spec:
     - $(params.CONTAINER_DISK_NAME)
     - "--enablevirtsysprep"
     - $(params.ENABLE_VIRT_SYSPREP)
+    - "--pushtimeout"
+    - $(params.PUSH_TIMEOUT)
     computeResources:
       requests:
         memory: "3Gi"

--- a/task/tests/kubevirt-disk-uploader-task-run.yaml
+++ b/task/tests/kubevirt-disk-uploader-task-run.yaml
@@ -14,3 +14,5 @@ spec:
     value: example-vm-tekton-exported:latest
   - name: ENABLE_VIRT_SYSPREP
     value: false
+  - name: PUSH_TIMEOUT
+    value: 120


### PR DESCRIPTION
Set containerDisk push timeout in
minutes. In some cases, it may take
longer to push VM disk out of the
cluster to container registry.

Jira-Url: https://issues.redhat.com/browse/CNV-36058