### PR TITLE
docs: add push timeout parameter

### DIFF
--- a/task/README.md
+++ b/task/README.md
@@ -58,4 +58,6 @@ spec:
     value: <CONTAINER_DISK_NAME_VALUE>
   - name: ENABLE_VIRT_SYSPREP
     value: <ENABLE_VIRT_SYSPREP_VALUE>
+  - name: PUSH_TIMEOUT
+    value: <PUSH_TIMEOUT>
 ```


### PR DESCRIPTION
Add missing PUSH_TIMEOUT in example
Tekton parameters.

Jira-Url: https://issues.redhat.com/browse/CNV-36058