### PR TITLE
docs: update installation link

### DIFF
--- a/task/0.5.0/README.md
+++ b/task/0.5.0/README.md
@@ -9,7 +9,7 @@ When user runs [KubeVirt Tekton Tasks](https://github.com/kubevirt/kubevirt-tekt
 # Installation
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/codingben/kubevirt-disk-uploader/v0.5.0/task/kubevirt-disk-uploader-task.yaml
+kubectl apply -f https://raw.githubusercontent.com/codingben/kubevirt-disk-uploader/0.5.0/task/kubevirt-disk-uploader-task.yaml
 ```
 
 # Parameters


### PR DESCRIPTION
Fix wrong version number in the Installation link.

Jira-Url: https://issues.redhat.com/browse/CNV-37578