### PR TITLE
fix: go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
fix: go version in Dockerfile

bump the go version to 1.22 in Dockerfile