### PR TITLE
[WIP]chore: use mounted pvc instead of vm-export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 COPY vendor/ ./vendor
 COPY main.go .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubevirt-disk-uploader .
+RUN CGO_ENABLED=0 GOOS=linux GODEBUG=http2client=0 GOARCH=amd64 go build -o kubevirt-disk-uploader .
 
 FROM quay.io/fedora/fedora-minimal:39
 

--- a/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
+++ b/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
@@ -33,7 +33,7 @@ spec:
     type: string
   steps:
   - name: kubevirt-disk-uploader-step
-    image: quay.io/boukhano/kubevirt-disk-uploader:v0.5.0
+    image: quay.io/ksimon/kubevirt-disk-uploader:latest
     env:
     - name: REGISTRY_USERNAME
       valueFrom:
@@ -66,3 +66,10 @@ spec:
         memory: "3Gi"
       limits:
         memory: "5Gi"
+    volumeMounts:
+      - mountPath: /tmp/targetpvc/
+        name: targetpvc
+  volumes:
+    - name: targetpvc
+      persistentVolumeClaim:
+        claimName: $(params.VOLUME_NAME)


### PR DESCRIPTION
Instead if using vm export, which consumes in cluster network resources and storage for converting the image, we can directly use the PVC. This reduces required resources and time required to finish the task.
Disk in mounted PVC is direclty used for building the image.
Do not merge - WIP

This commit is missing checks if the pvc is used by running VM