### PR TITLE
feat(CNV-48461): use nbdkit to download disk img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubevirt-disk-uploader .
 
 FROM quay.io/fedora/fedora-minimal:39
 
-RUN cd /usr/bin && \
-    curl -L https://github.com/kubevirt/kubevirt/releases/download/v1.0.0/virtctl-v1.0.0-linux-amd64 --output virtctl && \
-    chmod +x virtctl && \
-    microdnf install -y qemu-img libguestfs-tools-c && \
-    microdnf clean all -y
+RUN microdnf install -y nbdkit qemu-img && microdnf clean all -y
 COPY --from=builder /app/kubevirt-disk-uploader /usr/local/bin/kubevirt-disk-uploader
 
 ENTRYPOINT ["/usr/local/bin/kubevirt-disk-uploader"]

--- a/examples/kubevirt-disk-uploader-tekton.yaml
+++ b/examples/kubevirt-disk-uploader-tekton.yaml
@@ -162,9 +162,6 @@ spec:
   - name: IMAGE_DESTINATION
     description: Destination of the image in container registry
     type: string
-  - name: ENABLE_VIRT_SYSPREP
-    description: Enable or disable preparation of disk image
-    type: string
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
@@ -194,8 +191,6 @@ spec:
     - $(params.VOLUME_NAME)
     - "--imagedestination"
     - $(params.IMAGE_DESTINATION)
-    - "--enablevirtsysprep"
-    - $(params.ENABLE_VIRT_SYSPREP)
     - "--pushtimeout"
     - $(params.PUSH_TIMEOUT)
     computeResources:
@@ -219,9 +214,6 @@ spec:
   - name: IMAGE_DESTINATION
     description: "Destination of the image in container registry"
     type: string
-  - name: ENABLE_VIRT_SYSPREP
-    description: "Enable or disable preparation of disk image"
-    type: string
   - name: PUSH_TIMEOUT
     description: "ContainerDisk push timeout in minutes"
     type: string
@@ -241,8 +233,6 @@ spec:
       value: "$(params.VOLUME_NAME)"
     - name: IMAGE_DESTINATION
       value: "$(params.IMAGE_DESTINATION)"
-    - name: ENABLE_VIRT_SYSPREP
-      value: "$(params.ENABLE_VIRT_SYSPREP)"
     - name: PUSH_TIMEOUT
       value: "$(params.PUSH_TIMEOUT)"
   - name: deploy-example-vm-exported
@@ -265,8 +255,6 @@ spec:
     value: datavolumedisk
   - name: IMAGE_DESTINATION
     value: quay.io/boukhano/example-vm-tekton-exported:latest
-  - name: ENABLE_VIRT_SYSPREP
-    value: true
   - name: PUSH_TIMEOUT
     value: 120
   taskRunTemplate:

--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -54,12 +54,18 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       command: ["/usr/local/bin/kubevirt-disk-uploader"]
-      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--imagedestination", "quay.io/boukhano/example-vm-exported:latest", "--enablevirtsysprep", "false", "--pushtimeout", "120"]
+      # args: ["--vmname", "example-vm", "--volumename", "datavolumedisk", "--imagedestination", "quay.io/boukhano/example-vm-exported:latest", "--pushtimeout", "120"]
       resources:
         requests:
           memory: 3Gi
         limits:
           memory: 5Gi
+      volumeMounts:
+        - name: disk
+          mountPath: /tmp
+  volumes:
+    - name: disk
+      emptyDir: {}
   restartPolicy: Never
 ---
 apiVersion: v1

--- a/tasks/kubevirt-disk-uploader/0.5.0/README.md
+++ b/tasks/kubevirt-disk-uploader/0.5.0/README.md
@@ -17,7 +17,6 @@ kubectl apply -f https://raw.githubusercontent.com/codingben/kubevirt-disk-uploa
 - **VM_NAME**: The name of the virtual machine
 - **VOLUME_NAME**: The volume name of the virtual machine
 - **IMAGE_DESTINATION**: Destination of the image in container registry
-- **ENABLE_VIRT_SYSPREP**: Enable or disable preparation of disk image
 - **PUSH_TIMEOUT**: ContainerDisk push timeout in minutes
 
 # Usage
@@ -55,8 +54,6 @@ spec:
     value: <VOLUME_NAME_VALUE>
   - name: IMAGE_DESTINATION
     value: <IMAGE_DESTINATION_VALUE>
-  - name: ENABLE_VIRT_SYSPREP
-    value: <ENABLE_VIRT_SYSPREP_VALUE>
   - name: PUSH_TIMEOUT
     value: <PUSH_TIMEOUT>
 ```

--- a/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
+++ b/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
@@ -25,9 +25,6 @@ spec:
   - name: IMAGE_DESTINATION
     description: Destination of the image in container registry
     type: string
-  - name: ENABLE_VIRT_SYSPREP
-    description: Enable or disable preparation of disk image
-    type: string
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
@@ -57,8 +54,6 @@ spec:
     - $(params.VOLUME_NAME)
     - "--imagedestination"
     - $(params.IMAGE_DESTINATION)
-    - "--enablevirtsysprep"
-    - $(params.ENABLE_VIRT_SYSPREP)
     - "--pushtimeout"
     - $(params.PUSH_TIMEOUT)
     computeResources:

--- a/tasks/kubevirt-disk-uploader/0.5.0/tests/kubevirt-disk-uploader-task-run.yaml
+++ b/tasks/kubevirt-disk-uploader/0.5.0/tests/kubevirt-disk-uploader-task-run.yaml
@@ -12,7 +12,5 @@ spec:
     value: datavolumedisk
   - name: IMAGE_DESTINATION
     value: quay.io/boukhano/example-vm-tekton-exported:latest
-  - name: ENABLE_VIRT_SYSPREP
-    value: false
   - name: PUSH_TIMEOUT
     value: 120


### PR DESCRIPTION
Use nbdkit to download raw disk img and
qemu-img to convert it to qcow2 format
directly from the remote server.

- Remove virt-sysprep
- Remove virtctl
- Remove gzip

Also add emptyDir volume to store the
converted disk qcow2 image.