### PR TITLE
fix(CNV-48780): rename credentials of the container registry

### DIFF
--- a/examples/kubevirt-disk-uploader-tekton.yaml
+++ b/examples/kubevirt-disk-uploader-tekton.yaml
@@ -144,8 +144,8 @@ metadata:
   name: kubevirt-disk-uploader-credentials-tekton
 type: Opaque
 data:
-  registryUsername: "<REGISTRY_USERNAME>"
-  registryPassword: "<REGISTRY_PASSWORD>"
+  accessKeyId: "<ACCESS_KEY_ID>"
+  secretKey: "<SECRET_KEY>"
 ---
 apiVersion: tekton.dev/v1
 kind: Task
@@ -169,16 +169,16 @@ spec:
   - name: kubevirt-disk-uploader-step
     image: quay.io/boukhano/kubevirt-disk-uploader:latest
     env:
-    - name: REGISTRY_USERNAME
+    - name: ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:
           name: kubevirt-disk-uploader-credentials-tekton
-          key: registryUsername
-    - name: REGISTRY_PASSWORD
+          key: accessKeyId
+    - name: SECRET_KEY
       valueFrom:
         secretKeyRef:
           name: kubevirt-disk-uploader-credentials-tekton
-          key: registryPassword
+          key: secretKey
     - name: VM_NAMESPACE
       valueFrom:
         fieldRef:

--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -39,16 +39,16 @@ spec:
       image: quay.io/boukhano/kubevirt-disk-uploader:latest
       imagePullPolicy: Always
       env:
-        - name: REGISTRY_USERNAME
+        - name: ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
               name: kubevirt-disk-uploader-credentials
-              key: registryUsername
-        - name: REGISTRY_PASSWORD
+              key: accessKeyId
+        - name: SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: kubevirt-disk-uploader-credentials
-              key: registryPassword
+              key: secretKey
         - name: VM_NAMESPACE
           valueFrom:
             fieldRef:
@@ -74,5 +74,5 @@ metadata:
   name: kubevirt-disk-uploader-credentials
 type: Opaque
 data:
-  registryUsername: "<REGISTRY_USERNAME>"
-  registryPassword: "<REGISTRY_PASSWORD>"
+  accessKeyId: "<ACCESS_KEY_ID>"
+  secretKey: "<SECRET_KEY>"

--- a/main.go
+++ b/main.go
@@ -149,13 +149,10 @@ func pushContainerDisk(image v1.Image, imageDestination string, pushTimeout int)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*time.Duration(pushTimeout))
 	defer cancel()
 
-	userName := os.Getenv("REGISTRY_USERNAME")
-	password := os.Getenv("REGISTRY_PASSWORD")
 	auth := &authn.Basic{
-		Username: userName,
-		Password: password,
+		Username: os.Getenv("ACCESS_KEY_ID"),
+		Password: os.Getenv("SECRET_KEY"),
 	}
-
 	err := crane.Push(image, imageDestination, crane.WithAuth(auth), crane.WithContext(ctx))
 	if err != nil {
 		log.Fatalf("Error pushing image: %v", err)

--- a/tasks/kubevirt-disk-uploader/0.5.0/README.md
+++ b/tasks/kubevirt-disk-uploader/0.5.0/README.md
@@ -33,8 +33,8 @@ metadata:
   name: kubevirt-disk-uploader-credentials-tekton
 type: Opaque
 data:
-  registryUsername: "<REGISTRY_USERNAME>"
-  registryPassword: "<REGISTRY_PASSWORD>"
+  accessKeyId: "<ACCESS_KEY_ID>"
+  secretKey: "<SECRET_KEY>"
 ```
 
 TaskRun:

--- a/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
+++ b/tasks/kubevirt-disk-uploader/0.5.0/kubevirt-disk-uploader.yaml
@@ -32,16 +32,16 @@ spec:
   - name: kubevirt-disk-uploader-step
     image: quay.io/boukhano/kubevirt-disk-uploader:v0.5.0
     env:
-    - name: REGISTRY_USERNAME
+    - name: ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:
           name: kubevirt-disk-uploader-credentials-tekton
-          key: registryUsername
-    - name: REGISTRY_PASSWORD
+          key: accessKeyId
+    - name: SECRET_KEY
       valueFrom:
         secretKeyRef:
           name: kubevirt-disk-uploader-credentials-tekton
-          key: registryPassword
+          key: secretKey
     - name: VM_NAMESPACE
       valueFrom:
         fieldRef:

--- a/tasks/kubevirt-disk-uploader/0.5.0/tests/kubevirt-disk-uploader-secret.yaml
+++ b/tasks/kubevirt-disk-uploader/0.5.0/tests/kubevirt-disk-uploader-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   name: kubevirt-disk-uploader-credentials-tekton
 type: Opaque
 data:
-  registryUsername: "<REGISTRY_USERNAME>"
-  registryPassword: "<REGISTRY_PASSWORD>"
+  accessKeyId: "<ACCESS_KEY_ID>"
+  secretKey: "<SECRET_KEY>"


### PR DESCRIPTION
Rename credentials to match containerized data importer naming convnetion:

- accessKeyId: "${id}"
- secretKey: "${token}"