### PR TITLE
feat(CNV-48772): export from multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,39 @@ Extracts disk and uploads it to a container registry.
 
 ## About
 
-A tool designed to automate the extraction of disks from KubeVirt Virtual Machines, package them into [Container Disks](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk), and upload them to the Container Registry.
+A tool designed to automate the extraction of disk, rebuild as [Container Disk](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) and upload to the Container Registry.
 
-## Workflow
+## Usage
 
-KubeVirt Disk Uploader -> Download VM Disk -> Build New Container Disk -> Push To Container Registry
+These are the supported export sources:
 
-## Installation
+- VirtualMachine (VM)
+- VirtualMachineSnapshot (VM Snapshot)
+- PersistentVolumeClaim (PVC)
+
+Data from the source can be exported only when it is not used.
 
 **Prerequisites**
 
-1. Ensure Virtual Machine (VM) is powered off. Data from VM can be exported only when it is not used.
-2. Modify [kubevirt-disk-uploader](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L58) arguments (VM Namespace, VM Name, Volume Name, Image Destination, Enable or Disable System Preparation and Push Timeout).
-3. Modify [kubevirt-disk-uploader-credentials](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L65-L74) of the external container registry (Username, Password and Hostname).
+- Modify [kubevirt-disk-uploader](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L58) arguments.
+- Modify [kubevirt-disk-uploader-credentials](https://github.com/codingben/kubevirt-disk-uploader/blob/main/kubevirt-disk-uploader.yaml#L65-L74) of the external container registry.
 
-Deploy `kubevirt-disk-uploader` within the same namespace as the Virtual Machine (VM):
+**Parameters**
+
+- **Export Source Kind**: Specify the export source kind (`vm`, `vmsnapshot`, `pvc`).
+- **Export Source Namespace**: The namespace of the export source.
+- **Export Source Name**: The name of the export source.
+- **Volume Name**:  The name of the volume to export data.
+- **Image Destination**: Destination of the image in container registry (`$HOST/$OWNER/$REPO:$TAG`).
+- **Push Timeout**: The push timeout of container disk to registry.
+
+Deploy `kubevirt-disk-uploader` within the same namespace of Export Source (VM, VM Snapshot, PVC):
 
 ```
 kubectl apply -f kubevirt-disk-uploader.yaml -n $POD_NAMESPACE
 ```
 
-**Note**: If both `POD_NAMESPACE` and `--vmnamespace` argument are set, `POD_NAMESPACE` will be used.
+Setting of environment variable `POD_NAMESPACE` overrides the value in `--export-source-namespace` if passed.
 
 ## KubeVirt Documentation
 

--- a/examples/kubevirt-disk-uploader-tekton.yaml
+++ b/examples/kubevirt-disk-uploader-tekton.yaml
@@ -156,11 +156,14 @@ metadata:
   name: kubevirt-disk-uploader-task
 spec:
   params:
-  - name: POD_NAME
-    description: The name of the virtual machine
+  - name: EXPORT_SOURCE_KIND
+    description: The name of the export source kind
+    type: string
+  - name: EXPORT_SOURCE_NAME
+    description: The name of the export source
     type: string
   - name: VOLUME_NAME
-    description: The volume name of the virtual machine
+    description: The volume name (If source kind is PVC, then volume name is equal to source name)
     type: string
   - name: IMAGE_DESTINATION
     description: Destination of the image in container registry
@@ -192,8 +195,10 @@ spec:
           fieldPath: metadata.name
     command: ["/usr/local/bin/kubevirt-disk-uploader"]
     args:
-    - "--vmname"
-    - $(params.POD_NAME)
+    - "--export-source-kind"
+    - $(params.EXPORT_SOURCE_KIND)
+    - "--export-source-name"
+    - $(params.EXPORT_SOURCE_NAME)
     - "--volumename"
     - $(params.VOLUME_NAME)
     - "--imagedestination"
@@ -212,17 +217,20 @@ metadata:
   name: kubevirt-disk-uploader-pipeline
 spec:
   params:
-  - name: POD_NAME
-    description: "Name of the virtual machine"
+  - name: EXPORT_SOURCE_KIND
+    description: "Kind of the export source"
+    type: string
+  - name: EXPORT_SOURCE_NAME
+    description: "Name of the export source"
     type: string
   - name: VOLUME_NAME
-    description: "Volume name of the virtual machine"
+    description: "Volume name (If source kind is PVC, then volume name is equal to source name)"
     type: string
   - name: IMAGE_DESTINATION
     description: "Destination of the image in container registry"
     type: string
   - name: PUSH_TIMEOUT
-    description: "ContainerDisk push timeout in minutes"
+    description: "Push timeout of container disk to registry"
     type: string
   tasks:
   - name: deploy-example-vm
@@ -234,8 +242,10 @@ spec:
     runAfter:
       - deploy-example-vm
     params:
-    - name: POD_NAME
-      value: "$(params.POD_NAME)"
+    - name: EXPORT_SOURCE_KIND
+      value: "$(params.EXPORT_SOURCE_KIND)"
+    - name: EXPORT_SOURCE_NAME
+      value: "$(params.EXPORT_SOURCE_NAME)"
     - name: VOLUME_NAME
       value: "$(params.VOLUME_NAME)"
     - name: IMAGE_DESTINATION
@@ -256,7 +266,9 @@ spec:
   pipelineRef:
     name: kubevirt-disk-uploader-pipeline
   params:
-  - name: POD_NAME
+  - name: EXPORT_SOURCE_KIND
+    value: vm
+  - name: EXPORT_SOURCE_NAME
     value: example-vm-tekton
   - name: VOLUME_NAME
     value: example-dv-tekton

--- a/kubevirt-disk-uploader.yaml
+++ b/kubevirt-disk-uploader.yaml
@@ -61,7 +61,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       command: ["/usr/local/bin/kubevirt-disk-uploader"]
-      # args: ["--vmname", "example-vm", "--volumename", "example-dv", "--imagedestination", "quay.io/boukhano/example-vm-exported:latest", "--pushtimeout", "120"]
+      # args: ["--export-source-kind", "vm", "--export-source-name", "example-vm", "--volumename", "example-dv", "--imagedestination", "quay.io/boukhano/example-vm-exported:latest", "--pushtimeout", "120"]
       resources:
         requests:
           memory: 3Gi

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -9,8 +9,8 @@ import (
 	kubecli "kubevirt.io/client-go/kubecli"
 )
 
-func GetCertificateFromVirtualMachineExport(client kubecli.KubevirtClient, vmNamespace, vmName string) (string, error) {
-	vmExport, err := client.VirtualMachineExport(vmNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
+func GetCertificateFromVirtualMachineExport(client kubecli.KubevirtClient, namespace, name string) (string, error) {
+	vmExport, err := client.VirtualMachineExport(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -14,7 +14,7 @@ import (
 	kubecli "kubevirt.io/client-go/kubecli"
 )
 
-func CreateVirtualMachineExportSecret(client kubecli.KubevirtClient, vmNamespace, vmName string) error {
+func CreateVirtualMachineExportSecret(client kubecli.KubevirtClient, namespace, name string) error {
 	length := 20
 	token, err := GenerateSecureRandomString(length)
 	if err != nil {
@@ -23,8 +23,8 @@ func CreateVirtualMachineExportSecret(client kubecli.KubevirtClient, vmNamespace
 
 	v1Secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmName,
-			Namespace: vmNamespace,
+			Name:      name,
+			Namespace: namespace,
 		},
 		StringData: map[string]string{
 			"token": token,
@@ -35,19 +35,19 @@ func CreateVirtualMachineExportSecret(client kubecli.KubevirtClient, vmNamespace
 		return err
 	}
 
-	_, err = client.CoreV1().Secrets(vmNamespace).Create(context.Background(), v1Secret, metav1.CreateOptions{})
+	_, err = client.CoreV1().Secrets(namespace).Create(context.Background(), v1Secret, metav1.CreateOptions{})
 	return err
 }
 
-func GetTokenFromVirtualMachineExportSecret(client kubecli.KubevirtClient, vmNamespace, vmName string) (string, error) {
-	secret, err := client.CoreV1().Secrets(vmNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
+func GetTokenFromVirtualMachineExportSecret(client kubecli.KubevirtClient, namespace, name string) (string, error) {
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
 
 	data := secret.Data["token"]
 	if len(data) == 0 {
-		return "", fmt.Errorf("failed to get export token from '%s/%s'", vmNamespace, vmName)
+		return "", fmt.Errorf("failed to get export token from '%s/%s'", namespace, name)
 	}
 	return string(data), nil
 }

--- a/pkg/vmexport/vmexport.go
+++ b/pkg/vmexport/vmexport.go
@@ -13,22 +13,38 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 	v1beta1 "kubevirt.io/api/export/v1beta1"
+	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	kubecli "kubevirt.io/client-go/kubecli"
 )
 
-func CreateVirtualMachineExport(client kubecli.KubevirtClient, vmNamespace, vmName string) error {
+const (
+	sourceVM         string = "vm"
+	sourceVMSnapshot string = "vmsnapshot"
+	sourcePVC        string = "pvc"
+)
+
+var (
+	exportSources = map[string]struct{}{sourceVM: {}, sourceVMSnapshot: {}, sourcePVC: {}}
+)
+
+func CreateVirtualMachineExport(client kubecli.KubevirtClient, exportSourceKind, exportSourceNamespace, exportSourceName string) error {
+	if !isValidExportSource(exportSourceKind) {
+		return fmt.Errorf("invalid export-source-kind: %s, must be one of vm, vmsnapshot, pvc", exportSourceKind)
+	}
+
+	source, err := getExportSource(exportSourceKind, exportSourceName)
+	if err != nil {
+		return err
+	}
+
 	v1VmExport := &v1beta1.VirtualMachineExport{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmName,
-			Namespace: vmNamespace,
+			Name:      exportSourceName,
+			Namespace: exportSourceNamespace,
 		},
 		Spec: v1beta1.VirtualMachineExportSpec{
-			TokenSecretRef: &vmName,
-			Source: corev1.TypedLocalObjectReference{
-				APIGroup: &kvcorev1.SchemeGroupVersion.Group,
-				Kind:     kvcorev1.VirtualMachineGroupVersionKind.Kind,
-				Name:     vmName,
-			},
+			TokenSecretRef: &exportSourceName,
+			Source:         source,
 		},
 	}
 
@@ -36,15 +52,15 @@ func CreateVirtualMachineExport(client kubecli.KubevirtClient, vmNamespace, vmNa
 		return err
 	}
 
-	_, err := client.VirtualMachineExport(vmNamespace).Create(context.Background(), v1VmExport, metav1.CreateOptions{})
+	_, err = client.VirtualMachineExport(exportSourceNamespace).Create(context.Background(), v1VmExport, metav1.CreateOptions{})
 	return err
 }
 
-func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, vmNamespace, vmName string) error {
+func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, namespace, name string) error {
 	pollInterval := 15 * time.Second
 	pollTimeout := 3600 * time.Second
 	poller := func(ctx context.Context) (bool, error) {
-		vmExport, err := client.VirtualMachineExport(vmNamespace).Get(ctx, vmName, metav1.GetOptions{})
+		vmExport, err := client.VirtualMachineExport(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -58,8 +74,8 @@ func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, vmNamespa
 	return wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, poller)
 }
 
-func GetRawDiskUrlFromVolumes(client kubecli.KubevirtClient, vmNamespace, vmName, volumeName string) (string, error) {
-	vmExport, err := client.VirtualMachineExport(vmNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
+func GetRawDiskUrlFromVolumes(client kubecli.KubevirtClient, namespace, name, volumeName string) (string, error) {
+	vmExport, err := client.VirtualMachineExport(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -80,4 +96,36 @@ func GetRawDiskUrlFromVolumes(client kubecli.KubevirtClient, vmNamespace, vmName
 		}
 	}
 	return "", fmt.Errorf("volume %s is not found in VirtualMachineExport internal volumes", volumeName)
+}
+
+func getExportSource(exportSourceKind, exportSourceName string) (corev1.TypedLocalObjectReference, error) {
+	switch exportSourceKind {
+	case sourceVM:
+		return corev1.TypedLocalObjectReference{
+			APIGroup: &kvcorev1.SchemeGroupVersion.Group,
+			Kind:     "VirtualMachine",
+			Name:     exportSourceName,
+		}, nil
+	case sourceVMSnapshot:
+		return corev1.TypedLocalObjectReference{
+			APIGroup: &snapshotv1.SchemeGroupVersion.Group,
+			Kind:     "VirtualMachineSnapshot",
+			Name:     exportSourceName,
+		}, nil
+	case sourcePVC:
+		return corev1.TypedLocalObjectReference{
+			APIGroup: &corev1.SchemeGroupVersion.Group,
+			Kind:     "PersistentVolumeClaim",
+			Name:     exportSourceName,
+		}, nil
+	default:
+		return corev1.TypedLocalObjectReference{}, fmt.Errorf("invalid export-source-kind: %s", exportSourceKind)
+	}
+}
+
+func isValidExportSource(exportSourceKind string) bool {
+	if _, ok := exportSources[exportSourceKind]; ok {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Currently kubevirt-disk-uploader is
hardcoded to export only from a single
source "VirtualMachine" (kind).

Extend API to allow export from multiple sources:

- VirtualMachine
- VirtualMachineSnapshot
- PersistentVolumeClaim